### PR TITLE
[StreamToHandshake] Feature registers lowering

### DIFF
--- a/include/circt-stream/Dialect/Stream/StreamOps.td
+++ b/include/circt-stream/Dialect/Stream/StreamOps.td
@@ -97,7 +97,7 @@ def ReduceOp : Stream_Op<"reduce", []> {
 
   let arguments = (
     ins StreamType:$input,
-    I64Attr:$initValue, 
+    I64Attr:$initValue,
     RegisterAttr:$registers);
 
   let results = (outs StreamType:$result);

--- a/integration_test/Dialect/Stream/combine-with-reg.mlir
+++ b/integration_test/Dialect/Stream/combine-with-reg.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: verilator
+
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+
+// CHECK: Element={{.*}}11
+// CHECK-NEXT: Element={{.*}}24
+// CHECK-NEXT: Element={{.*}}39
+// CHECK-NEXT: EOS
+
+module {
+  func.func @top() -> (!stream.stream<i64>) {
+    %in0 = stream.create !stream.stream<i64> [1,2,3]
+    %in1 = stream.create !stream.stream<i64> [10,11,12]
+    %res = stream.combine(%in0, %in1) {registers = [0 : i64]} : (!stream.stream<i64>, !stream.stream<i64>) -> (!stream.stream<i64>) {
+    ^0(%val0: i64, %val1: i64, %reg: i64):
+      %0 = arith.addi %val0, %val1 : i64
+      %nReg = arith.addi %0, %reg : i64
+      stream.yield %nReg, %nReg : i64, i64
+    }
+    return %res : !stream.stream<i64>
+  }
+}

--- a/integration_test/Dialect/Stream/filter-with-reg.mlir
+++ b/integration_test/Dialect/Stream/filter-with-reg.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: verilator
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// CHECK:      Element={{.*}}1
+// CHECK-NEXT: Element={{.*}}0
+// CHECK-NEXT: Element={{.*}}0
+// CHECK-NEXT: EOS
+
+module {
+  func.func @top() -> !stream.stream<i64> {
+    %in = stream.create !stream.stream<i64> [0,1,2,0,4,0]
+    %out = stream.filter(%in) {registers = [0 : i1]}: (!stream.stream<i64>) -> !stream.stream<i64> {
+    ^bb0(%val: i64, %reg: i1):
+      %c1 = arith.constant 1 : i1
+      %nReg = arith.xori %c1, %reg : i1
+      stream.yield %reg, %nReg : i1, i1
+    }
+    return %out : !stream.stream<i64>
+  }
+}

--- a/integration_test/Dialect/Stream/map-with-reg.mlir
+++ b/integration_test/Dialect/Stream/map-with-reg.mlir
@@ -1,0 +1,24 @@
+// REQUIRES: verilator
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+
+// CHECK:      Element={{.*}}1
+// CHECK-NEXT: Element={{.*}}3
+// CHECK-NEXT: Element={{.*}}6
+// CHECK-NEXT: EOS
+
+module {
+  func.func @top() -> !stream.stream<i64> {
+    %in = stream.create !stream.stream<i64> [1,2,3]
+    %res = stream.map(%in) {registers = [0: i64]}: (!stream.stream<i64>) -> !stream.stream<i64> {
+      ^0(%val : i64, %reg: i64):
+      %nReg = arith.addi %val, %reg : i64
+      stream.yield %nReg, %nReg : i64, i64
+    }
+    return %res : !stream.stream<i64>
+  }
+}

--- a/integration_test/Dialect/Stream/reduce-with-reg.mlir
+++ b/integration_test/Dialect/Stream/reduce-with-reg.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: verilator
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// CHECK:      Element={{.*}}36
+// CHECK-NEXT: EOS
+
+module {
+  func.func @top() -> !stream.stream<i64> {
+    %in = stream.create !stream.stream<i64> [1,2,3]
+    %out = stream.reduce(%in) {initValue = 0 : i64, registers = [10 : i64]}: (!stream.stream<i64>) -> !stream.stream<i64> {
+    ^0(%acc: i64, %val: i64, %reg: i64):
+      %r = arith.addi %acc, %val : i64
+      %res = arith.addi %r, %reg : i64
+      stream.yield %res, %reg : i64, i64
+    }
+    return %out : !stream.stream<i64>
+  }
+}

--- a/integration_test/Dialect/Stream/split-with-reg.mlir
+++ b/integration_test/Dialect/Stream/split-with-reg.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: verilator
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=all --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// RUN: stream-opt %s --convert-stream-to-handshake \
+// RUN:   --canonicalize='top-down=true region-simplify=true' \
+// RUN:   --handshake-materialize-forks-sinks --canonicalize \
+// RUN:   --handshake-insert-buffers=strategy=allFIFO --lower-handshake-to-firrtl | \
+// RUN: firtool --format=mlir --verilog > %t.sv && \
+// RUN: circt-rtl-sim.py %t.sv %S/driver_out_i64_i64.sv %S/driver.cpp --no-default-driver --top driver | FileCheck %s
+// CHECK-DAG: S0: Element={{.*}}1
+// CHECK-DAG: S0: Element={{.*}}2
+// CHECK-DAG: S0: Element={{.*}}3
+// CHECK-DAG: S1: Element={{.*}}1
+// CHECK-DAG: S1: Element={{.*}}3
+// CHECK-DAG: S1: Element={{.*}}5
+// CHECK-NOT: ensures that the later appears after the former
+// CHECK-DAG: S0: EOS
+// CHECK-DAG: S1: EOS
+
+module {
+  func.func @top() -> (!stream.stream<i64>, !stream.stream<i64>) {
+    %in = stream.create !stream.stream<i64> [1,2,3]
+    %res0, %res1 = stream.split(%in) {registers = [0 : i64]}: (!stream.stream<i64>) -> (!stream.stream<i64>, !stream.stream<i64>) {
+      ^0(%val: i64, %reg: i64):
+      %snd = arith.addi %val, %reg : i64
+      stream.yield %val, %snd, %val : i64, i64, i64
+    }
+    return %res0, %res1 : !stream.stream<i64>, !stream.stream<i64>
+  }
+}

--- a/test/Conversion/StreamToHandshake/registers.mlir
+++ b/test/Conversion/StreamToHandshake/registers.mlir
@@ -1,0 +1,62 @@
+// RUN: stream-opt %s --convert-stream-to-handshake --split-input-file | FileCheck %s
+
+// CHECK-LABEL:   handshake.func private @stream_map(
+// CHECK-SAME:      %[[VAL_0:.*]]: tuple<i32, i1>, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...) -> (tuple<i32, i1>, none, none)
+// CHECK:           %[[VAL_3:.*]]:2 = unpack %[[VAL_0]] : tuple<i32, i1>
+// CHECK:           %[[VAL_4:.*]] = buffer [1] seq %[[VAL_5:.*]] {initValues = [0]} : i32
+// CHECK:           %[[VAL_6:.*]] = merge %[[VAL_3]]#0 : i32
+// CHECK:           %[[VAL_5]] = merge %[[VAL_4]] : i32
+// CHECK:           %[[VAL_7:.*]] = pack %[[VAL_6]], %[[VAL_3]]#1 : tuple<i32, i1>
+// CHECK:           return %[[VAL_7]], %[[VAL_1]], %[[VAL_2]] : tuple<i32, i1>, none, none
+// CHECK:         }
+
+
+// CHECK-LABEL:   handshake.func @single_reg(
+// CHECK-SAME:      %[[VAL_0:.*]]: tuple<i32, i1>, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...) -> none
+// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] : none
+// CHECK:           %[[VAL_4:.*]]:3 = instance @stream_map(%[[VAL_0]], %[[VAL_1]], %[[VAL_3]]#1) : (tuple<i32, i1>, none, none) -> (tuple<i32, i1>, none, none)
+
+func.func @single_reg(%in: !stream.stream<i32>) {
+  %res = stream.map(%in) {registers = [0 : i32]}: (!stream.stream<i32>) -> !stream.stream<i32> {
+  ^0(%val : i32, %reg: i32):
+    stream.yield %val, %reg : i32, i32
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   handshake.func private @stream_filter(
+// CHECK-SAME:      %[[VAL_0:.*]]: tuple<i32, i1>, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...)
+// CHECK:           %[[VAL_3:.*]]:2 = unpack %[[VAL_0]] : tuple<i32, i1>
+// CHECK:           %[[VAL_4:.*]]:2 = fork [2] %[[VAL_3]]#1 : i1
+// CHECK:           %[[VAL_5:.*]]:2 = fork [2] %[[VAL_3]]#0 : i32
+// CHECK:           %[[VAL_6:.*]] = buffer [1] seq %[[VAL_7:.*]] {initValues = [0]} : i1
+// CHECK:           %[[VAL_8:.*]] = buffer [1] seq %[[VAL_9:.*]]#1 {initValues = [-1]} : i1
+// CHECK:           %[[VAL_10:.*]] = merge %[[VAL_5]]#0 : i32
+// CHECK:           sink %[[VAL_10]] : i32
+// CHECK:           %[[VAL_11:.*]] = merge %[[VAL_6]] : i1
+// CHECK:           %[[VAL_9]]:2 = fork [2] %[[VAL_11]] : i1
+// CHECK:           %[[VAL_7]] = merge %[[VAL_8]] : i1
+// CHECK:           %[[VAL_12:.*]] = pack %[[VAL_5]]#1, %[[VAL_4]]#1 : tuple<i32, i1>
+// CHECK:           %[[VAL_13:.*]] = arith.ori %[[VAL_9]]#0, %[[VAL_4]]#0 : i1
+// CHECK:           %[[VAL_14:.*]]:2 = fork [2] %[[VAL_13]] : i1
+// CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]] = cond_br %[[VAL_14]]#1, %[[VAL_12]] : tuple<i32, i1>
+// CHECK:           sink %[[VAL_16]] : tuple<i32, i1>
+// CHECK:           %[[VAL_17:.*]], %[[VAL_18:.*]] = cond_br %[[VAL_14]]#0, %[[VAL_1]] : none
+// CHECK:           sink %[[VAL_18]] : none
+// CHECK:           return %[[VAL_15]], %[[VAL_17]], %[[VAL_2]] : tuple<i32, i1>, none, none
+// CHECK:         }
+
+// CHECK-LABEL:   handshake.func @multiple_regs(
+// CHECK-SAME:      %[[VAL_0:.*]]: tuple<i32, i1>, %[[VAL_1:.*]]: none, %[[VAL_2:.*]]: none, ...) -> none
+// CHECK:           %[[VAL_3:.*]]:2 = fork [2] %[[VAL_2]] : none
+// CHECK:           %[[VAL_4:.*]]:3 = instance @stream_filter(%[[VAL_0]], %[[VAL_1]], %[[VAL_3]]#1) : (tuple<i32, i1>, none, none) -> (tuple<i32, i1>, none, none)
+
+func.func @multiple_regs(%in: !stream.stream<i32>) {
+  %res = stream.filter(%in) {registers = [0 : i1, 1 : i1]}: (!stream.stream<i32>) -> !stream.stream<i32> {
+  ^0(%val : i32, %reg0: i1, %reg1 : i1):
+    stream.yield %reg0, %reg1, %reg0 : i1, i1, i1
+  }
+  return
+}


### PR DESCRIPTION
This PR implements lowering support for registers. As of now, this only supports integer registers, as handshake buffers do unfortunately not support other types for initial values.