### PR TITLE
[StreamToHandshake] Reset registers on EOS for reuse

### DIFF
--- a/integration_test/Dialect/Stream/filter-with-reg/filter-with-reg.py
+++ b/integration_test/Dialect/Stream/filter-with-reg/filter-with-reg.py
@@ -14,3 +14,17 @@ async def ascendingInputs(dut):
   cocotb.start_soon(in0.sendAndTerminate([0,1,2,0,4,0]))
 
   await out0Check
+
+@cocotb.test()
+async def multipleEOS(dut):
+  ins, outs = await initDut(dut)
+
+  in0 = Stream(ins[0], ins[1])
+  out0 = Stream(outs[0], outs[1])
+
+  for _ in range(5):
+    out0Check = cocotb.start_soon(out0.checkOutputs([1,0,0]))
+
+    cocotb.start_soon(in0.sendAndTerminate([0,1,2,0,4,0]))
+
+    await out0Check

--- a/integration_test/Dialect/Stream/filter/filter.py
+++ b/integration_test/Dialect/Stream/filter/filter.py
@@ -14,3 +14,17 @@ async def ascendingInputs(dut):
   cocotb.start_soon(in0.sendAndTerminate([0,1,2,0,4,0]))
 
   await out0Check
+
+@cocotb.test()
+async def multipleEOS(dut):
+  ins, outs = await initDut(dut)
+
+  in0 = Stream(ins[0], ins[1])
+  out0 = Stream(outs[0], outs[1])
+
+  for _ in range(5):
+    out0Check = cocotb.start_soon(out0.checkOutputs([1,2,4]))
+
+    cocotb.start_soon(in0.sendAndTerminate([0,1,2,0,4,0]))
+
+    await out0Check

--- a/integration_test/Dialect/Stream/map-with-reg/map-with-reg.py
+++ b/integration_test/Dialect/Stream/map-with-reg/map-with-reg.py
@@ -14,3 +14,17 @@ async def ascendingInputs(dut):
   cocotb.start_soon(in0.sendAndTerminate([1,2,3]))
 
   await out0Check
+
+@cocotb.test()
+async def multipleEOS(dut):
+  ins, outs = await initDut(dut)
+
+  in0 = Stream(ins[0], ins[1])
+  out0 = Stream(outs[0], outs[1])
+
+  for _ in range(5):
+    out0Check = cocotb.start_soon(out0.checkOutputs([1,3,6]))
+
+    cocotb.start_soon(in0.sendAndTerminate([1,2,3]))
+
+    await out0Check

--- a/integration_test/Dialect/Stream/map/map.py
+++ b/integration_test/Dialect/Stream/map/map.py
@@ -14,3 +14,16 @@ async def ascendingInputs(dut):
   cocotb.start_soon(in0.sendAndTerminate([1,2,3]))
 
   await out0Check
+
+@cocotb.test()
+async def multipleEOS(dut):
+  ins, outs = await initDut(dut)
+
+  in0 = Stream(ins[0], ins[1])
+  out0 = Stream(outs[0], outs[1])
+
+  for _ in range(5):
+    out0Check = cocotb.start_soon(out0.checkOutputs([11,12,13]))
+    sending = cocotb.start_soon(in0.sendAndTerminate([1,2,3]))
+
+    await out0Check

--- a/integration_test/Dialect/Stream/stream-stats/stream-stats.py
+++ b/integration_test/Dialect/Stream/stream-stats/stream-stats.py
@@ -11,7 +11,7 @@ async def sendOne(dut):
   out0 = Stream(outs[0], outs[1])
   out1 = Stream(outs[2], outs[3])
 
-  inputs = [(10,2,3,6,5,1,5,9)]
+  inputs = [(10, 2, 3, 6, 5, 1, 5, 9)]
   outputs = [max([max(list(i)) for i in inputs])]
 
   out0Check = cocotb.start_soon(out0.checkOutputs(inputs))
@@ -21,6 +21,7 @@ async def sendOne(dut):
 
   await out0Check
   await out1Check
+
 
 def randomTuple():
   return tuple([random.randint(0, 100) for _ in range(8)])
@@ -45,3 +46,25 @@ async def sendMultiple(dut):
 
   await out0Check
   await out1Check
+
+
+@cocotb.test()
+async def sendMultipleWithEOS(dut):
+  ins, outs = await initDut(dut)
+
+  in0 = Stream(ins[0], ins[1])
+  out0 = Stream(outs[0], outs[1])
+  out1 = Stream(outs[2], outs[3])
+
+  for _ in range(5):
+    N = 100
+    inputs = [randomTuple() for _ in range(N)]
+    outputs = [max([max(list(i)) for i in inputs])]
+
+    out0Check = cocotb.start_soon(out0.checkOutputs(inputs))
+    out1Check = cocotb.start_soon(out1.checkOutputs(outputs))
+
+    cocotb.start_soon(in0.sendAndTerminate(inputs))
+
+    await out0Check
+    await out1Check


### PR DESCRIPTION
This change ensures not only that lambda is not executed on EOS, but additionally resets the registers on EOS.

Fixes #79 and fixes #82