### PR TITLE
[Infrastructure] Add missing link dependency

### DIFF
--- a/lib/Conversion/StreamToHandshake/CMakeLists.txt
+++ b/lib/Conversion/StreamToHandshake/CMakeLists.txt
@@ -13,5 +13,6 @@ add_mlir_library(CIRCTStreamStreamToHandshake
   MLIRFuncDialect
 
   CIRCTHandshake
+  CIRCTStreamStream
   )
 


### PR DESCRIPTION
This commit fixes the make builds as it enforces the generation of the dialect before the conversion is built.

Fixes #93 